### PR TITLE
Terraform 0.13 and submodule/provider updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 jobs:
   lint-terraform:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        terraform-version: [0.12.29, 0.13.4]
+        tflint-version: [0.20.2]
     steps:
       - name: Install Terraform
         run: |
@@ -12,7 +16,7 @@ jobs:
           sudo mv terraform /usr/local/bin/
           rm terraform_${TF_VERSION}_linux_amd64.zip
         env:
-          TF_VERSION: 0.12.18
+          TF_VERSION: ${{ matrix.terraform-version }}
 
       - name: Install tflint
         run: |
@@ -21,7 +25,7 @@ jobs:
           sudo mv tflint /usr/local/bin/
           rm tflint_linux_amd64.zip
         env:
-          TFLINT_VERSION: 0.13.2
+          TFLINT_VERSION: ${{ matrix.tflint-version }}
 
       - uses: actions/checkout@v1
       - run: terraform fmt -check

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.4.0"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.5.0"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 1.3"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.70"
+    }
+  }
+  required_version = ">= 0.12"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 1.3"
+      version = ">= 1.3"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.70"
+      version = ">= 2.70"
     }
   }
   required_version = ">= 0.12"


### PR DESCRIPTION
The terraform-label submodule needs version 0.5.0 to work with tf 0.13. Also updated aws provider dependency to allow for wider range.