### PR TITLE
Make event_type_ids dynamic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.21.0
+  rev: v1.48.0
   hooks:
     - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -48,19 +48,41 @@ resource automatically creates the required service-linked role, which
 typically is nearly instantaneous. Just reapply your Terraform plan and you
 should be good to go.
 
+# Module documentation
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| archive | ~> 1.3 |
+| aws | ~> 2.70 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| archive | ~> 1.3 |
+| aws | ~> 2.70 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| attributes | List of attributes to add to label | list | `[]` | no |
-| codepipelines | CodePipeline resources that should trigger Slack notifications | list | n/a | yes |
-| name | Name \(unique identifier for app or service\) | string | n/a | yes |
-| namespace | Namespace \(e.g. `skynet`\) | string | n/a | yes |
-| slack\_channel | A slack channel to send the deployment notifications to | string | n/a | yes |
-| slack\_emoji | The emoji avatar of the user that sends the notifications | string | `":rocket:"` | no |
-| slack\_url | Slack webhook URL for deploy notifications | string | n/a | yes |
-| slack\_username | The name of the user that sends the notifications | string | `"Deploy Bot"` | no |
-| stage | Stage \(e.g. `prod`, `dev`, `staging`\) | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| attributes | List of attributes to add to label | `list(any)` | `[]` | no |
+| codepipelines | CodePipeline resources that should trigger Slack notifications | `list(any)` | n/a | yes |
+| event\_type\_ids | The list of event type to trigger a notification on | `list(any)` | <pre>[<br>  "codepipeline-pipeline-pipeline-execution-failed",<br>  "codepipeline-pipeline-pipeline-execution-canceled",<br>  "codepipeline-pipeline-pipeline-execution-started",<br>  "codepipeline-pipeline-pipeline-execution-resumed",<br>  "codepipeline-pipeline-pipeline-execution-succeeded",<br>  "codepipeline-pipeline-pipeline-execution-superseded"<br>]</pre> | no |
+| name | Name (unique identifier for app or service) | `string` | n/a | yes |
+| namespace | Namespace (e.g. `skynet`) | `string` | n/a | yes |
+| slack\_channel | A slack channel to send the deployment notifications to | `string` | n/a | yes |
+| slack\_emoji | The emoji avatar of the user that sends the notifications | `string` | `":rocket:"` | no |
+| slack\_url | Slack webhook URL for deploy notifications | `string` | n/a | yes |
+| slack\_username | The name of the user that sends the notifications | `string` | `"Deploy Bot"` | no |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
+
+## Outputs
+
+No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/lambdas/notifier/notifier.py
+++ b/lambdas/notifier/notifier.py
@@ -62,8 +62,8 @@ def format_slack_attachment(
     }
 
 
-def format_slack_text(*, pipeline_name: str, pipeline_state: str):
-    return f"Deployment of *{pipeline_name}* has {pipeline_state.lower()}."
+def format_slack_text(*, pipeline_name: str, pipeline_state: str, action: str = "Deployment"):
+    return f"*{action}* of *{pipeline_name}* has {pipeline_state.lower()}."
 
 
 def build_slack_message_from_event(event):
@@ -72,6 +72,7 @@ def build_slack_message_from_event(event):
     region = message["region"]
     pipeline_name = message["detail"]["pipeline"]
     pipeline_state = message["detail"]["state"]
+    pipeline_action = message["detail"].get('action')
     execution_id = message["detail"]["execution-id"]
 
     # Retrieve extra information about the pipeline run
@@ -84,7 +85,7 @@ def build_slack_message_from_event(event):
     revision_summary = revision.get("revisionSummary")
 
     # Build a message with an attachment with details
-    text = format_slack_text(pipeline_name=pipeline_name, pipeline_state=pipeline_state)
+    text = format_slack_text(pipeline_name=pipeline_name, pipeline_state=pipeline_state, action=pipeline_action)
     attachment = format_slack_attachment(
         pipeline_name=pipeline_name,
         pipeline_state=pipeline_state,

--- a/lambdas/notifier/notifier.py
+++ b/lambdas/notifier/notifier.py
@@ -62,10 +62,7 @@ def format_slack_attachment(
     }
 
 
-def format_slack_text(*,
-                      pipeline_name: str,
-                      pipeline_state: str,
-                      action: str = "Deployment"):
+def format_slack_text(*, pipeline_name: str, pipeline_state: str, action: str):
     return f"*{action}* of *{pipeline_name}* has {pipeline_state.lower()}."
 
 
@@ -75,7 +72,7 @@ def build_slack_message_from_event(event):
     region = message["region"]
     pipeline_name = message["detail"]["pipeline"]
     pipeline_state = message["detail"]["state"]
-    pipeline_action = message["detail"].get('action')
+    pipeline_action = message["detail"].get("action")
     execution_id = message["detail"]["execution-id"]
 
     # Retrieve extra information about the pipeline run
@@ -88,9 +85,11 @@ def build_slack_message_from_event(event):
     revision_summary = revision.get("revisionSummary")
 
     # Build a message with an attachment with details
-    text = format_slack_text(pipeline_name=pipeline_name,
-                             pipeline_state=pipeline_state,
-                             action=pipeline_action)
+    text = format_slack_text(
+        pipeline_name=pipeline_name,
+        pipeline_state=pipeline_state,
+        action=pipeline_action or "Deployment",
+    )
     attachment = format_slack_attachment(
         pipeline_name=pipeline_name,
         pipeline_state=pipeline_state,

--- a/lambdas/notifier/notifier.py
+++ b/lambdas/notifier/notifier.py
@@ -62,7 +62,10 @@ def format_slack_attachment(
     }
 
 
-def format_slack_text(*, pipeline_name: str, pipeline_state: str, action: str = "Deployment"):
+def format_slack_text(*,
+                      pipeline_name: str,
+                      pipeline_state: str,
+                      action: str = "Deployment"):
     return f"*{action}* of *{pipeline_name}* has {pipeline_state.lower()}."
 
 
@@ -85,7 +88,9 @@ def build_slack_message_from_event(event):
     revision_summary = revision.get("revisionSummary")
 
     # Build a message with an attachment with details
-    text = format_slack_text(pipeline_name=pipeline_name, pipeline_state=pipeline_state, action=pipeline_action)
+    text = format_slack_text(pipeline_name=pipeline_name,
+                             pipeline_state=pipeline_state,
+                             action=pipeline_action)
     attachment = format_slack_attachment(
         pipeline_name=pipeline_name,
         pipeline_state=pipeline_state,

--- a/lambdas/notifier/tests.py
+++ b/lambdas/notifier/tests.py
@@ -112,7 +112,7 @@ class TestNotifier(unittest.TestCase):
                 "channel": "#notifications",
                 "username": "Mr. Robot",
                 "icon_emoji": ":rocket:",
-                "text": "Deployment of *kjagiello-qa-homepage* has started.",
+                "text": "*Deployment* of *kjagiello-qa-homepage* has started.",
                 "attachments": [
                     {
                         "color": "#1a9edb",

--- a/main.tf
+++ b/main.tf
@@ -21,11 +21,11 @@ resource "aws_sns_topic_subscription" "pipeline_updates" {
 }
 
 resource "aws_codestarnotifications_notification_rule" "pipeline_updates" {
-  count       = length(var.codepipelines)
-  detail_type = "FULL"
+  count          = length(var.codepipelines)
+  detail_type    = "FULL"
   event_type_ids = var.event_type_ids
-  name     = "slackNotification${var.codepipelines[count.index].name}"
-  resource = var.codepipelines[count.index].arn
+  name           = "slackNotification${var.codepipelines[count.index].name}"
+  resource       = var.codepipelines[count.index].arn
 
   target {
     address = aws_sns_topic.pipeline_updates.arn

--- a/main.tf
+++ b/main.tf
@@ -23,14 +23,7 @@ resource "aws_sns_topic_subscription" "pipeline_updates" {
 resource "aws_codestarnotifications_notification_rule" "pipeline_updates" {
   count       = length(var.codepipelines)
   detail_type = "FULL"
-  event_type_ids = [
-    "codepipeline-pipeline-pipeline-execution-failed",
-    "codepipeline-pipeline-pipeline-execution-canceled",
-    "codepipeline-pipeline-pipeline-execution-started",
-    "codepipeline-pipeline-pipeline-execution-resumed",
-    "codepipeline-pipeline-pipeline-execution-succeeded",
-    "codepipeline-pipeline-pipeline-execution-superseded",
-  ]
+  event_type_ids = var.event_type_ids
   name     = "slackNotification${var.codepipelines[count.index].name}"
   resource = var.codepipelines[count.index].arn
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,16 @@ variable "slack_emoji" {
   description = "The emoji avatar of the user that sends the notifications"
   default     = ":rocket:"
 }
+
+variable "event_type_ids" {
+  type = list
+  description = "The list of event type to trigger a notification on"
+  default = [
+    "codepipeline-pipeline-pipeline-execution-failed",
+    "codepipeline-pipeline-pipeline-execution-canceled",
+    "codepipeline-pipeline-pipeline-execution-started",
+    "codepipeline-pipeline-pipeline-execution-resumed",
+    "codepipeline-pipeline-pipeline-execution-succeeded",
+    "codepipeline-pipeline-pipeline-execution-superseded"
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,13 +14,13 @@ variable "stage" {
 }
 
 variable "attributes" {
-  type        = list
+  type        = list(any)
   description = "List of attributes to add to label"
   default     = []
 }
 
 variable "codepipelines" {
-  type        = list
+  type        = list(any)
   description = "CodePipeline resources that should trigger Slack notifications"
 }
 
@@ -47,7 +47,7 @@ variable "slack_emoji" {
 }
 
 variable "event_type_ids" {
-  type = list
+  type        = list(any)
   description = "The list of event type to trigger a notification on"
   default = [
     "codepipeline-pipeline-pipeline-execution-failed",


### PR DESCRIPTION
At November Five we were looking for a Terraform module which triggered slack messages on pipeline actions. 
This module helped us a lot, thanks for that. 
We did however have the need to also get notifications on Manual approval steps of the pipeline, so I made a few changes to support this. It is now possible to provide the list of event types which you want to receive notifications of.
I also made the slack message a bit more dynamic based on the type of event.