### PR TITLE
Allow usage with AWS v4 provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform-version: [ 0.12.30, 0.13.6, 0.14.10, 0.15.0 ]
+        terraform-version: [ 0.12.30, 0.13.6, 0.14.10, 0.15.0, 1.1.9 ]
     steps:
       - uses: actions/checkout@v2
       - run: terraform fmt -check
@@ -74,7 +74,7 @@ jobs:
           python-version: 3.8
 
       - name: Install dependencies
-        run: pip install --pre flake8==3.9.0 black==20.8b1
+        run: pip install --pre flake8==4.0.1 black==22.3.0
 
       - uses: actions/checkout@v2
       - run: flake8
@@ -99,7 +99,7 @@ jobs:
       # 3.8 lambda. See the link below for reference.
       # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
       - name: Install dependencies
-        run: pip install boto3==1.16.31 botocore==1.19.31
+        run: pip install boto3==1.20.32 botocore==1.23.32
 
       - uses: actions/checkout@v2
       - run: python -m tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.48.0
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.71.1
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.17.1
+  rev: v1.71.0
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.71.1
+  rev: v1.17.1
   hooks:
     - id: terraform_fmt
     - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ should be good to go.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.70, < 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.70, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 1.3 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.70, < 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.70, < 5.0 |
 
 ## Inputs
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.33"
+      version = "~> 4.0"
     }
   }
   required_version = ">= 0.12"

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.70, < 4.0"
+      version = ">= 2.70, < 5.0"
     }
   }
   required_version = ">= 0.12"


### PR DESCRIPTION
I have tested the compatibility with the AWS v4 provider and everything worked just fine, so I'm adjusting the version lock accordingly. 

Closes #20.