### PR TITLE
feat: append name to codestar notification rule to allow creating a unique name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform-version: [ 0.12.30, 0.13.6, 0.14.10, 0.15.0, 1.1.9 ]
+        terraform-version: [ 0.13.6, 0.14.10, 0.15.0, 1.1.9, 1.5.0 ]
     steps:
       - uses: actions/checkout@v2
       - run: terraform fmt -check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       TERRAFORM_VERSION: 0.15.0
       TFLINT_VERSION: 0.26.0
       TFSEC_VERSION: 0.39.21
-      TERRAFORM_DOCS_VERSION: 0.12.1
+      TERRAFORM_DOCS_VERSION: 0.16.0
     steps:
       - name: Install Terraform
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,4 +6,4 @@ repos:
     - id: terraform_validate
     - id: terraform_tfsec
     - id: terraform_docs
-      args: ['--args=--hide modules,resources']
+      args: ['--args=--hide modules,resources,providers']

--- a/README.md
+++ b/README.md
@@ -55,32 +55,44 @@ should be good to go.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.70, < 5.0 |
 
-## Providers
+## Resources
 
-| Name | Version |
-|------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 1.3 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.70, < 5.0 |
+| Name | Type |
+|------|------|
+| [archive_file.notifier_package](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_iam_policy_document.pipeline_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.pipeline_notification_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.pipeline_updates_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_attributes"></a> [attributes](#input\_attributes) | List of attributes to add to label | `list(any)` | `[]` | no |
+| <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| <a name="input_attributes"></a> [attributes](#input\_attributes) | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | <a name="input_codepipelines"></a> [codepipelines](#input\_codepipelines) | CodePipeline resources that should trigger Slack notifications | `list(any)` | n/a | yes |
+| <a name="input_context"></a> [context](#input\_context) | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | `any` | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| <a name="input_delimiter"></a> [delimiter](#input\_delimiter) | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_event_type_ids"></a> [event\_type\_ids](#input\_event\_type\_ids) | The list of event type to trigger a notification on | `list(any)` | <pre>[<br>  "codepipeline-pipeline-pipeline-execution-failed",<br>  "codepipeline-pipeline-pipeline-execution-canceled",<br>  "codepipeline-pipeline-pipeline-execution-started",<br>  "codepipeline-pipeline-pipeline-execution-resumed",<br>  "codepipeline-pipeline-pipeline-execution-succeeded",<br>  "codepipeline-pipeline-pipeline-execution-superseded"<br>]</pre> | no |
-| <a name="input_name"></a> [name](#input\_name) | Name (unique identifier for app or service) | `string` | n/a | yes |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace (e.g. `skynet`) | `string` | n/a | yes |
+| <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`.<br>Default value: `title`. | `string` | `null` | no |
+| <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br>Default value: `lower`. | `string` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | A slack channel to send the deployment notifications to | `string` | n/a | yes |
 | <a name="input_slack_emoji"></a> [slack\_emoji](#input\_slack\_emoji) | The emoji avatar of the user that sends the notifications | `string` | `":rocket:"` | no |
 | <a name="input_slack_url"></a> [slack\_url](#input\_slack\_url) | Slack webhook URL for deploy notifications | `string` | n/a | yes |
 | <a name="input_slack_username"></a> [slack\_username](#input\_slack\_username) | The name of the user that sends the notifications | `string` | `"Deploy Bot"` | no |
-| <a name="input_stage"></a> [stage](#input\_stage) | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
+| <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/context.tf
+++ b/context.tf
@@ -1,0 +1,202 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "aws_codestarnotifications_notification_rule" "pipeline_updates" {
   count          = length(var.codepipelines)
   detail_type    = "FULL"
   event_type_ids = var.event_type_ids
-  name           = "slackNotification${var.codepipelines[count.index].name}"
+  name           = join("-", ["slackNotification${var.codepipelines[count.index].name}", module.default_label.name])
   resource       = var.codepipelines[count.index].arn
 
   target {

--- a/main.tf
+++ b/main.tf
@@ -154,7 +154,7 @@ resource "aws_iam_policy" "pipeline_notification" {
 
   policy = data.aws_iam_policy_document.pipeline_notification.json
 
-  tags = module.default_label.tags
+  tags = module.this.tags
 }
 
 resource "aws_iam_role_policy_attachment" "pipeline_notification" {

--- a/main.tf
+++ b/main.tf
@@ -1,20 +1,16 @@
-module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.22.0"
-  namespace  = var.namespace
-  stage      = var.stage
-  name       = var.name
-  attributes = var.attributes
-  tags       = var.tags
-}
+module "subscription_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
 
-locals {
-  subscription_name = "${module.default_label.id}-pipeline-updates"
+  attributes = ["pipeline", "updates"]
+
+  context = module.this.context
 }
 
 resource "aws_sns_topic" "pipeline_updates" {
   # tfsec:ignore:AWS016
-  name = local.subscription_name
-  tags = module.default_label.tags
+  name = module.subscription_label.id
+  tags = module.this.tags
 }
 
 resource "aws_sns_topic_subscription" "pipeline_updates" {
@@ -24,18 +20,18 @@ resource "aws_sns_topic_subscription" "pipeline_updates" {
 }
 
 resource "aws_codestarnotifications_notification_rule" "pipeline_updates" {
-  count          = length(var.codepipelines)
+  for_each       = { for pipeline in var.codepipelines : pipeline.name => pipeline.arn }
   detail_type    = "FULL"
   event_type_ids = var.event_type_ids
-  name           = join("-", ["slackNotification${var.codepipelines[count.index].name}", module.default_label.name])
-  resource       = var.codepipelines[count.index].arn
+  name           = join("-", [each.key, module.this.name])
+  resource       = each.value
 
   target {
     address = aws_sns_topic.pipeline_updates.arn
     type    = "SNS"
   }
 
-  tags = module.default_label.tags
+  tags = module.this.tags
 }
 
 resource "aws_sns_topic_policy" "pipeline_updates" {
@@ -71,7 +67,7 @@ data "archive_file" "notifier_package" {
 
 resource "aws_lambda_function" "pipeline_notification" {
   filename         = "${path.module}/lambdas/notifier.zip"
-  function_name    = module.default_label.id
+  function_name    = module.this.id
   role             = aws_iam_role.pipeline_notification.arn
   runtime          = "python3.8"
   source_code_hash = data.archive_file.notifier_package.output_base64sha256
@@ -88,7 +84,7 @@ resource "aws_lambda_function" "pipeline_notification" {
     }
   }
 
-  tags = module.default_label.tags
+  tags = module.this.tags
 
   depends_on = [
     aws_iam_role_policy_attachment.pipeline_notification,
@@ -115,11 +111,11 @@ data "aws_iam_policy_document" "pipeline_notification_role" {
 }
 
 resource "aws_iam_role" "pipeline_notification" {
-  name = "${module.default_label.id}-pipeline-notification"
+  name = "${module.this.id}-pipeline-notification"
 
   assume_role_policy = data.aws_iam_policy_document.pipeline_notification_role.json
 
-  tags = module.default_label.tags
+  tags = module.this.tags
 }
 
 data "aws_iam_policy_document" "pipeline_notification" {
@@ -152,7 +148,7 @@ data "aws_iam_policy_document" "pipeline_notification" {
 }
 
 resource "aws_iam_policy" "pipeline_notification" {
-  name        = "${module.default_label.id}-pipeline-notification"
+  name        = "${module.this.id}-pipeline-notification"
   path        = "/"
   description = "IAM policy for the Slack notification lambda"
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,30 +1,3 @@
-variable "name" {
-  type        = string
-  description = "Name (unique identifier for app or service)"
-}
-
-variable "namespace" {
-  type        = string
-  description = "Namespace (e.g. `skynet`)"
-}
-
-variable "stage" {
-  type        = string
-  description = "Stage (e.g. `prod`, `dev`, `staging`)"
-}
-
-variable "attributes" {
-  type        = list(any)
-  description = "List of attributes to add to label"
-  default     = []
-}
-
-variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
-}
-
 variable "codepipelines" {
   type        = list(any)
   description = "CodePipeline resources that should trigger Slack notifications"

--- a/versions.tf
+++ b/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 2.70, < 5.0"
     }
   }
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
- to allow multiple notifications module instances to be attached to the same codepipeline