### PR TITLE
Require AWS provider v5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ should be good to go.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.70, < 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Resources
 

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.70, < 5.0"
+      version = ">= 5.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Superseding https://github.com/kjagiello/terraform-aws-codepipeline-slack-notifications/pull/26. Created as a separate PR, because I did not have permissions to update the fork branch on that PR.