### PR TITLE
Require Terraform 1.5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ should be good to go.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.12"
+  required_version = ">= 1.5"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
 }


### PR DESCRIPTION
At the moment the oldest Terraform version still receiving security updates is 1.5, so let's drop the older versions.