### PR TITLE
Stop using deprecated resources

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -37,7 +37,7 @@ resource "aws_codepipeline" "codepipeline" {
 
       configuration = {
         S3Bucket    = aws_s3_bucket.source_bucket.bucket
-        S3ObjectKey = aws_s3_bucket_object.source_object.key
+        S3ObjectKey = aws_s3_object.source_object.key
       }
     }
   }
@@ -90,7 +90,7 @@ resource "aws_s3_bucket" "source_bucket" {
   }
 }
 
-resource "aws_s3_bucket_object" "source_object" {
+resource "aws_s3_object" "source_object" {
   bucket  = aws_s3_bucket.source_bucket.bucket
   key     = "test"
   content = "test"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -61,13 +61,28 @@ resource "aws_codepipeline" "codepipeline" {
 resource "aws_s3_bucket" "artifact_bucket" {
   # tfsec:ignore:AWS002
   bucket = "notifications-test-artifact-bucket"
-  acl    = "private"
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_ownership_controls" "artifact_bucket" {
+  bucket = aws_s3_bucket.artifact_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "artifact_bucket" {
+  depends_on = [aws_s3_bucket_ownership_controls.artifact_bucket]
+
+  bucket = aws_s3_bucket.artifact_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "artifact_bucket" {
+  bucket = aws_s3_bucket.artifact_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }
@@ -75,18 +90,38 @@ resource "aws_s3_bucket" "artifact_bucket" {
 resource "aws_s3_bucket" "source_bucket" {
   # tfsec:ignore:AWS002
   bucket = "notifications-test-source-bucket"
-  acl    = "private"
+}
 
-  versioning {
-    enabled = true
+resource "aws_s3_bucket_ownership_controls" "source_bucket" {
+  bucket = aws_s3_bucket.source_bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
   }
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_acl" "source_bucket" {
+  depends_on = [aws_s3_bucket_ownership_controls.source_bucket]
+
+  bucket = aws_s3_bucket.source_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "source_bucket" {
+  bucket = aws_s3_bucket.source_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "source_bucket" {
+  bucket = aws_s3_bucket.source_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 


### PR DESCRIPTION
Resolving these deprecation warnings:
```
╷
│ Warning: Deprecated attribute
│
│   on main.tf line 40, in resource "aws_codepipeline" "codepipeline":
│   40:         S3ObjectKey = aws_s3_bucket_object.source_object.key
│
│ The attribute "key" is deprecated. Refer to the provider documentation for details.
│
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: Argument is deprecated
│
│   with aws_s3_bucket.artifact_bucket,
│   on main.tf line 61, in resource "aws_s3_bucket" "artifact_bucket":
│   61: resource "aws_s3_bucket" "artifact_bucket" {
│
│ Use the aws_s3_bucket_server_side_encryption_configuration resource instead
│
│ (and 12 more similar warnings elsewhere)
╵
╷
│ Warning: Deprecated Resource
│
│   with aws_s3_bucket_object.source_object,
│   on main.tf line 93, in resource "aws_s3_bucket_object" "source_object":
│   93: resource "aws_s3_bucket_object" "source_object" {
│
│ use the aws_s3_object resource instead
│
│ (and one more similar warning elsewhere)
╵
│ Warning: Argument is deprecated
│
│   with aws_s3_bucket.artifact_bucket,
│   on main.tf line 64, in resource "aws_s3_bucket" "artifact_bucket":
│   64:   acl    = "private"
│
│ Use the aws_s3_bucket_acl resource instead

```