### PR TITLE
Use data_archive.output_path instead of path_module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ data "archive_file" "notifier_package" {
 }
 
 resource "aws_lambda_function" "pipeline_notification" {
-  filename         = "${path.module}/lambdas/notifier.zip"
+  filename         = data.archive_file.notifier_package.output_path
   function_name    = module.this.id
   role             = aws_iam_role.pipeline_notification.arn
   runtime          = "python3.8"


### PR DESCRIPTION
## Motivation

Terraform lambda `source_code_hash` parameter always shows drift changes if plan/apply runs in different OS systems