### PR TITLE
Preventing state drift changes across different operating systems when no changes have been made

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "pipeline_updates_policy" {
 data "archive_file" "notifier_package" {
   type        = "zip"
   source_file = "${path.module}/lambdas/notifier/notifier.py"
-  output_file_mode = "0666"
+  output_file_mode = "0777"
   output_path = "${path.module}/lambdas/notifier.zip"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -83,10 +83,10 @@ data "aws_iam_policy_document" "pipeline_updates_policy" {
 }
 
 data "archive_file" "notifier_package" {
-  type        = "zip"
-  source_file = "${path.module}/lambdas/notifier/notifier.py"
+  type             = "zip"
+  source_file      = "${path.module}/lambdas/notifier/notifier.py"
   output_file_mode = "0666"
-  output_path = "${path.module}/lambdas/notifier.zip"
+  output_path      = "${path.module}/lambdas/notifier.zip"
 }
 
 resource "aws_lambda_function" "pipeline_notification" {

--- a/main.tf
+++ b/main.tf
@@ -89,7 +89,7 @@ data "archive_file" "notifier_package" {
 }
 
 resource "aws_lambda_function" "pipeline_notification" {
-  filename         = "${path.module}/lambdas/notifier.zip"
+  filename         = data.archive_file.notifier_package.output_path
   function_name    = module.this.id
   role             = aws_iam_role.pipeline_notification.arn
   runtime          = "python3.8"

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,7 @@ data "aws_iam_policy_document" "pipeline_updates_policy" {
 data "archive_file" "notifier_package" {
   type        = "zip"
   source_file = "${path.module}/lambdas/notifier/notifier.py"
-  output_file_mode = "0777"
+  output_file_mode = "0666"
   output_path = "${path.module}/lambdas/notifier.zip"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,7 @@ data "aws_iam_policy_document" "pipeline_updates_policy" {
 data "archive_file" "notifier_package" {
   type        = "zip"
   source_file = "${path.module}/lambdas/notifier/notifier.py"
+  output_file_mode = "0666"
   output_path = "${path.module}/lambdas/notifier.zip"
 }
 


### PR DESCRIPTION
The `archive_file` data source can generate state drift due to different umask values in different operating systems, even when no changes have been made. However, there's a solution to this problem: using `output_file_mode` parameter to handle OS discrepancies and `output_path` output instead of `path.module` to build the path.

> Note: These changes have already been tested on both Linux and OSx systems.

#### References
- https://github.com/hashicorp/terraform-provider-archive/issues/34
- https://github.com/hashicorp/terraform-provider-archive/issues/53